### PR TITLE
对比从原版3dgs的cuda代码,fix一个关于计算mid时的笔误

### DIFF
--- a/3dgs.py
+++ b/3dgs.py
@@ -158,7 +158,7 @@ class Rasterizer:
 
             # compute radius, by finding eigenvalues of 2d covariance
             # transfrom point from NDC to Pixel
-            mid = 0.5 * (cov[0] + cov[1])
+            mid = 0.5 * (cov[0] + cov[2])
             lambda1 = mid + sqrt(max(0.1, mid * mid - det))
             lambda2 = mid - sqrt(max(0.1, mid * mid - det))
             my_radius = ceil(3 * sqrt(max(lambda1, lambda2)))


### PR DESCRIPTION
从原版3dgs的cuda代码中来看,计算`mid`时应该使用 `cov` 的第0个和第2个元素相加 

python版本和cuda版本的代码中, `cov[0]`, `cov[1]` 和 `cov[2]` 应分别表示 sx, covxy, sy, 故而这里应该写为 0.5 * (cov[0] + cov[2])


![image](https://github.com/user-attachments/assets/e049b77c-242b-424c-b9e7-eb3a9c80e4be)
